### PR TITLE
$repos->blob(..) returns array, updated to account

### DIFF
--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -54,7 +54,7 @@ $fetch_composer = function($project, $ref) use ($repos) {
     try {
         $data = array();
         $c = $repos->blob($project['id'], $ref, 'composer.json');
-        $composer = json_decode($c, true);
+        $composer = is_array($c) ? $c : json_decode($c, true);
 
         if (empty($composer['name']) || $composer['name'] != $project['path_with_namespace']) {
             return false; // packages must have a name and must match


### PR DESCRIPTION
Under my gitlab install, $repos->blob(..) returns an array, not a string as expected. As I'm not sure if this is the same behaviour across the board added ternary statement to catch this.
