### PR TITLE
added empty cache folder in git and install script that chmods, also support for dev-version branches

### DIFF
--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "m4tthumphrey/php-gitlab-api": "dev-master"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "chmod 777 cache"
+        ]
     }
 }

--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -100,6 +100,13 @@ $fetch_refs = function($project) use ($fetch_ref, $repos) {
 
     foreach (array_merge($repos->branches($project['id']), $repos->tags($project['id'])) as $ref) {
         foreach ($fetch_ref($project, $ref) as $version => $data) {
+			/*
+			 * duplicate branches that look like version numbers, so we can use both "dev-2.0 and 2.0"
+			 */
+			if(substr($version,0,4) !== 'dev-' ){
+				$datas['dev-'.$version] = $data;
+				$datas['dev-'.$version]['version'] = 'dev-'.$version;
+			}
             $datas[$version] = $data;
         }
     }


### PR DESCRIPTION
Automatic cache folder chmod should make installation easier for beginners.

The other issue we had with the branches was was this:
Once you create a branch that looks like a version number, eg: 2.0
And you tell composer to use "2.0" this works fine, however new commits will never be installed, because when you do "composer update", composer already sees there is a 2.0 installed, and will not update.
The solution is to put "dev-2.0", however this cannot be found in the current json.

Listing all branches that look like version numbers twice (once as 2.0 and once as dev-2.0) fixed this.

Kind regards
Jim