### PR TITLE
Fixed: A RuntimeException is thrown while fetching refs from empty repository (with no commits)

### DIFF
--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -98,10 +98,14 @@ $fetch_ref = function($project, $ref) use ($fetch_composer) {
 $fetch_refs = function($project) use ($fetch_ref, $repos) {
     $datas = array();
 
-    foreach (array_merge($repos->branches($project['id']), $repos->tags($project['id'])) as $ref) {
-        foreach ($fetch_ref($project, $ref) as $version => $data) {
-            $datas[$version] = $data;
+    try {
+        foreach (array_merge($repos->branches($project['id']), $repos->tags($project['id'])) as $ref) {
+            foreach ($fetch_ref($project, $ref) as $version => $data) {
+                $datas[$version] = $data;
+            }
         }
+    } catch (RuntimeException $e) {
+        // The repo has no commits — skipping it.
     }
 
     return $datas;


### PR DESCRIPTION
Hello!
This resolves the Issue #6.