### PR TITLE
added ability to add in a static reference to a 3rd party lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/confs/static-repos.json
 /vendor
 /composer.lock

--- a/confs/samples/static-repos.json
+++ b/confs/samples/static-repos.json
@@ -1,0 +1,25 @@
+{
+	"bige/sitech": {
+		"1.2": {
+			"name": "bige/sitech",
+			"version": "1.2",
+			"source": {
+				"url": "https://github.com/BigE/SiTech",
+				"type": "git",
+				"reference": "889eb1677b78ad83b12a0235cbb6d9bcec63ad9d"
+			},
+			"autoload": {
+				"classmap": ["lib/"],
+				"psr-0": {"SiTech_": "lib/"}
+			},
+			"autoload-dev": {
+				"classmap": [
+					"Tests/", "Tools/"
+				]
+			}
+			,"include-path": [
+				"lib/"
+			]
+		}
+	}
+}

--- a/confs/samples/static-repos.json
+++ b/confs/samples/static-repos.json
@@ -20,6 +20,9 @@
 			,"include-path": [
 				"lib/"
 			]
+			,"extra": {
+				"_source": "static"
+			}
 		}
 	}
 }

--- a/confs/samples/static-repos.json
+++ b/confs/samples/static-repos.json
@@ -20,9 +20,6 @@
 			,"include-path": [
 				"lib/"
 			]
-			,"extra": {
-				"_source": "static"
-			}
 		}
 	}
 }

--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -172,7 +172,9 @@ if (!file_exists($packages_file) || filemtime($packages_file) < $mtime) {
         foreach ( $static_packages as $name => $package ) {
             foreach ( $package as $version => $root ) {
                 if ( isset( $root->extra ) ) {
-                    $root->extra->_source = 'static';
+                    if ( !isset( $root->extra->_source ) ) {
+                        $root->extra->_source = 'static';
+                    }
                 }
                 else {
                     $root->extra = array(

--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -6,6 +6,7 @@ use Gitlab\Client;
 use Gitlab\Exception\RuntimeException;
 
 $packages_file = __DIR__ . '/../cache/packages.json';
+$static_file = __DIR__ . '/../confs/static-repos.json';
 
 /**
  * Output a json file, sending max-age header, then dies
@@ -164,6 +165,12 @@ if (!file_exists($packages_file) || filemtime($packages_file) < $mtime) {
     foreach ($all_projects as $project) {
         if ($package = $load_data($project)) {
             $packages[$project['path_with_namespace']] = $package;
+        }
+    }
+    if ( file_exists( $static_file ) ) {
+        $static_packages = json_decode( file_get_contents( $static_file ) );
+        foreach ( $static_packages as $name => $package ) {
+            $packages[$name] = $package;
         }
     }
     $data = json_encode(array(

--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -170,6 +170,16 @@ if (!file_exists($packages_file) || filemtime($packages_file) < $mtime) {
     if ( file_exists( $static_file ) ) {
         $static_packages = json_decode( file_get_contents( $static_file ) );
         foreach ( $static_packages as $name => $package ) {
+            foreach ( $package as $version => $root ) {
+                if ( isset( $root->extra ) ) {
+                    $root->extra->_source = 'static';
+                }
+                else {
+                    $root->extra = array(
+                        '_source' => 'static',
+                    );
+                }
+            }
             $packages[$name] = $package;
         }
     }

--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -172,8 +172,15 @@ if (!file_exists($packages_file) || filemtime($packages_file) < $mtime) {
         foreach ( $static_packages as $name => $package ) {
             foreach ( $package as $version => $root ) {
                 if ( isset( $root->extra ) ) {
-                    if ( !isset( $root->extra->_source ) ) {
-                        $root->extra->_source = 'static';
+                    $source = '_source';
+                    while ( true ) {
+                        if ( !isset( $root->extra->{$source} ) ) {
+                            $root->extra->{$source} = 'static';
+                            break;
+                        }
+                        else {
+                            $source = '_' . $source;
+                        }
                     }
                 }
                 else {

--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -173,15 +173,10 @@ if (!file_exists($packages_file) || filemtime($packages_file) < $mtime) {
             foreach ( $package as $version => $root ) {
                 if ( isset( $root->extra ) ) {
                     $source = '_source';
-                    while ( true ) {
-                        if ( !isset( $root->extra->{$source} ) ) {
-                            $root->extra->{$source} = 'static';
-                            break;
-                        }
-                        else {
-                            $source = '_' . $source;
-                        }
+                    while ( isset( $root->extra->{$source} ) ) {
+                        $source = '_' . $source;
                     }
+                    $root->extra->{$source} = 'static';
                 }
                 else {
                     $root->extra = array(


### PR DESCRIPTION
I've needed to pull in 3rd party libraries as well so I don't have to manually list them in all of the composer.json files for different projects. I can change the static-repos.json sample to a different project if you want me to, just let me know.