### PR TITLE
Cache folder should be writable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "m4tthumphrey/php-gitlab-api": "dev-master"
+    },
+    "scripts": {
+        "post-update-cmd": [
+            "chmod 777 cache"
+        ]
     }
 }


### PR DESCRIPTION
Why not let composer do it automatically?