### PR TITLE
Fix: is_admin isn't availabe after update to gitlab v9

### DIFF
--- a/htdocs/packages.php
+++ b/htdocs/packages.php
@@ -162,7 +162,8 @@ $all_projects = array();
 $mtime = 0;
 
 $me = $client->api('users')->me();
-if ((bool)$me['is_admin']) {
+// User is admin
+if ((bool)$me['can_create_group']) {
 	$projects_api_method = 'all';
 } else {
 	$projects_api_method = 'accessible';


### PR DESCRIPTION
Since Gitlab v9.1.0 the user has no is_admin property
https://gitlab.com/gitlab-org/gitlab-ce/commit/5e1a802b15af4ba991f9ed85a691f1a925cc0edf