### PR TITLE
Allow mismatches in package names. Fixes #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ See [example](examples/packages.json).
 Simply include a composer.json in your project, all branches and tags respecting 
 the [formats for versions](http://getcomposer.org/doc/04-schema.md#version) will be detected.
 
-Only requirement is that the package `name` must be equal to the path of the project. i.e.: `my-group/my-project`.
+By default, the package `name` must be equal to the path of the project. i.e.: `my-group/my-project`.
 This is not a design requirement, it is mostly to prevent common errors when you copy a `composer.json`
-from another project without changing its name.
+from another project without changing its name. To enable support for differences between package names and project
+paths, set `allow_package_name_mismatch` to `true` in `confs/gitlab.ini`.
 
 Then, to use your repository, add this in the `composer.json` of your project:
 ```json

--- a/confs/samples/gitlab.ini
+++ b/confs/samples/gitlab.ini
@@ -5,6 +5,10 @@
 endpoint="http://gitlab.example.com/api/v4/"
 api_key="ASDFGHJKL12345678"
 method="ssh"
+
 ; You can restrict to some gitlab groups:
 ;groups[]="one_group"
 ;groups[]="other_group"
+
+; Allow package names to differ from their group/project names in GitLab
+;allow_package_name_mismatch=true


### PR DESCRIPTION
Requiring the vendor/package to be the same as the group/project is a good
default to help prevent copy-paste errors and such.
However, in situations where the GitLab structure is simply different from
the vendor/package names, it should be possible to overwrite this behavior.